### PR TITLE
Setup cross-platform builds using github actions

### DIFF
--- a/.github/workflows/github-linux.yml
+++ b/.github/workflows/github-linux.yml
@@ -1,0 +1,31 @@
+name: Linux build
+on: [push, pull_request]
+jobs:
+    random-build-name:
+      runs-on: ubuntu-latest
+      timeout-minutes: 10
+      strategy:
+        matrix:
+          python-version: [3.7, 3.8]
+      steps:
+        - uses: actions/checkout@v2
+        - name: Setup python ${{ matrix.python-version }}
+          uses: actions/setup-python@v2
+          with:
+            python-version:  ${{ matrix.python-version }}
+        - name: Install dependencies
+          run: |
+            source $CONDA/bin/activate
+            conda config --add channels conda-forge
+            conda create --name neutron-imaging python==${{ matrix.python-version }}
+            conda activate neutron-imaging
+            conda env update --file=conda/environment.yml
+            conda install pytest
+        - name: Run tests
+          run: |
+            source $CONDA/bin/activate
+            conda activate neutron-imaging
+            python --version
+            pwd
+            cd notebooks
+            PYTHONPATH=. pytest

--- a/.github/workflows/github-linux.yml
+++ b/.github/workflows/github-linux.yml
@@ -8,7 +8,7 @@ jobs:
         matrix:
           os: [ubuntu-latest, windows-latest, macOS-latest]
           python-version: [3.7, 3.8]
-      name: ${{ matrix.os }} python ${{ matrix.python-version }}
+      name: ${{ matrix.os }} py${{ matrix.python-version }}
       steps:
         - uses: actions/checkout@v2
         - name: Setup python ${{ matrix.python-version }}
@@ -16,21 +16,24 @@ jobs:
           with:
             python-version:  ${{ matrix.python-version }}
         - name: Setup conda
-          uses: s-weigand/setup-conda@v1
+          uses: conda-incubator/setup-miniconda@v2
           with:
-            update-conda: false
+            activate-environment: neutron-imaging
+            environment-file: conda/environment.yml
             python-version: ${{ matrix.python-version }}
-            conda-channels: conda-forge
+            channels: conda-forge
+            #condarc-file: etc/example-condarc.yml
+            auto-activate-base: false
         - name: Install dependencies
           run: |
-            source $CONDA/bin/activate
+            #source $CONDA/bin/activate
             conda create --name neutron-imaging python==${{ matrix.python-version }}
             conda activate neutron-imaging
             conda env update --file=conda/environment.yml
             conda install pytest
         - name: Run tests
           run: |
-            source $CONDA/bin/activate
+            #source $CONDA/bin/activate
             conda activate neutron-imaging
             python --version
             pwd

--- a/.github/workflows/github-linux.yml
+++ b/.github/workflows/github-linux.yml
@@ -6,33 +6,41 @@ jobs:
       timeout-minutes: 10
       strategy:
         matrix:
-          os: [ubuntu-latest, windows-latest, macOS-latest]
           python-version: [3.7, 3.8]
-      name: ${{ matrix.os }} python ${{ matrix.python-version }}
+          os: [macOS-latest, ubuntu-latest, windows-latest]
+          include:
+            - os: macOS-latest
+              shell_exec: "bash -c"
+              activate_cmd: "source $CONDA/bin/activate"
+            - os: ubuntu-latest
+              shell_exec: "bash -c"
+              activate_cmd: "source $CONDA/bin/activate"
+            - os: "windows-latest"
+              shell_exec: "cmd.exe /c"
+              activate_cmd: "activate"
+      name: ${{ matrix.os }} py${{ matrix.python-version }}
       steps:
         - uses: actions/checkout@v2
-        - name: Setup python ${{ matrix.python-version }}
-          uses: actions/setup-python@v2
+        - uses: s-weigand/setup-conda@v1.0.5
+          name: Setup Conda
           with:
-            python-version:  ${{ matrix.python-version }}
-        - name: Setup conda
-          uses: s-weigand/setup-conda@v1
-          with:
-            update-conda: false
             python-version: ${{ matrix.python-version }}
-            conda-channels: conda-forge
+            conda-channels: anaconda, conda-forge
+            activate-conda: true
+        - name: Check versions
+          run: |
+            conda --version
+            which python
+            python --version
+            pwd
         - name: Install dependencies
           run: |
-            #source $CONDA/bin/activate
-            conda env create --name neutron-imaging python==${{ matrix.python-version }}
-            conda activate neutron-imaging
-            conda env update --file=conda/environment.yml
+            conda env update -n base --file=conda/environment.yml
             conda install pytest
+        - run: conda env list
         - name: Run tests
           run: |
-            #source $CONDA/bin/activate
-            conda activate neutron-imaging
-            python --version
+            which python
             pwd
             cd notebooks
             PYTHONPATH=. pytest

--- a/.github/workflows/github-linux.yml
+++ b/.github/workflows/github-linux.yml
@@ -13,10 +13,15 @@ jobs:
           uses: actions/setup-python@v2
           with:
             python-version:  ${{ matrix.python-version }}
+        - name: Setup conda
+          uses: s-weigand/setup-conda@v1
+          with:
+            update-conda: false
+            python-version: ${{ matrix.python-version }}
+            conda-channels: conda-forge
         - name: Install dependencies
           run: |
             source $CONDA/bin/activate
-            conda config --add channels conda-forge
             conda create --name neutron-imaging python==${{ matrix.python-version }}
             conda activate neutron-imaging
             conda env update --file=conda/environment.yml

--- a/.github/workflows/github-linux.yml
+++ b/.github/workflows/github-linux.yml
@@ -8,16 +8,6 @@ jobs:
         matrix:
           python-version: [3.7, 3.8]
           os: [macOS-latest, ubuntu-latest, windows-latest]
-          include:
-            - os: macOS-latest
-              shell_exec: "bash -c"
-              activate_cmd: "source $CONDA/bin/activate"
-            - os: ubuntu-latest
-              shell_exec: "bash -c"
-              activate_cmd: "source $CONDA/bin/activate"
-            - os: "windows-latest"
-              shell_exec: "cmd.exe /c"
-              activate_cmd: "activate"
       name: ${{ matrix.os }} py${{ matrix.python-version }}
       steps:
         - uses: actions/checkout@v2
@@ -33,14 +23,12 @@ jobs:
             which python
             python --version
             pwd
+            ls
         - name: Install dependencies
           run: |
             conda env update -n base --file=conda/environment.yml
             conda install pytest
-        - run: conda env list
         - name: Run tests
           run: |
-            which python
-            pwd
             cd notebooks
             PYTHONPATH=. pytest

--- a/.github/workflows/github-linux.yml
+++ b/.github/workflows/github-linux.yml
@@ -2,11 +2,13 @@ name: Linux build
 on: [push, pull_request]
 jobs:
     random-build-name:
-      runs-on: ubuntu-latest
+      runs-on: ${{ matrix.os }}
       timeout-minutes: 10
       strategy:
         matrix:
+          os: [ubuntu-latest, windows-latest, macOS-latest]
           python-version: [3.7, 3.8]
+      name: ${{ matrix.os }} python ${{ matrix.python-version }}
       steps:
         - uses: actions/checkout@v2
         - name: Setup python ${{ matrix.python-version }}

--- a/.github/workflows/github-linux.yml
+++ b/.github/workflows/github-linux.yml
@@ -8,7 +8,7 @@ jobs:
         matrix:
           os: [ubuntu-latest, windows-latest, macOS-latest]
           python-version: [3.7, 3.8]
-      name: ${{ matrix.os }} py${{ matrix.python-version }}
+      name: ${{ matrix.os }} python ${{ matrix.python-version }}
       steps:
         - uses: actions/checkout@v2
         - name: Setup python ${{ matrix.python-version }}
@@ -16,18 +16,15 @@ jobs:
           with:
             python-version:  ${{ matrix.python-version }}
         - name: Setup conda
-          uses: conda-incubator/setup-miniconda@v2
+          uses: s-weigand/setup-conda@v1
           with:
-            activate-environment: neutron-imaging
-            environment-file: conda/environment.yml
+            update-conda: false
             python-version: ${{ matrix.python-version }}
-            channels: conda-forge
-            #condarc-file: etc/example-condarc.yml
-            auto-activate-base: false
+            conda-channels: conda-forge
         - name: Install dependencies
           run: |
             #source $CONDA/bin/activate
-            conda create --name neutron-imaging python==${{ matrix.python-version }}
+            conda env create --name neutron-imaging python==${{ matrix.python-version }}
             conda activate neutron-imaging
             conda env update --file=conda/environment.yml
             conda install pytest

--- a/conda/environment-dev.yml
+++ b/conda/environment-dev.yml
@@ -7,12 +7,13 @@ dependencies:
   - requests
   - requests-oauthlib
   - numpy
+  - h5py
   - scipy
   - pandas
   - scikit-image
   - matplotlib
   - plotly
-  - nodejs
+  - nodejs=15.14.0
   - qtpy
   - pyqtgraph=0.11.0
   - nodejs=15.14.0

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - requests
   - requests-oauthlib
   - numpy
+  - h5py
   - scipy
   - pandas
   - scikit-image

--- a/notebooks/__code/_utilities/file.py
+++ b/notebooks/__code/_utilities/file.py
@@ -436,7 +436,7 @@ def get_list_of_all_files_in_subfolders(folder="", extensions=['tiff', 'tif']):
 
 def read_bragg_edge_fitting_ascii_format(full_file_name):
     if not Path(full_file_name).exists():
-        raise FileNotFoundError
+        raise FileNotFoundError(str(full_file_name))
 
     metadata = {'detector_offset': '',
                 'distance_detector_sample': '',

--- a/notebooks/__code/file_handler.py
+++ b/notebooks/__code/file_handler.py
@@ -398,7 +398,7 @@ def get_list_of_all_files_in_subfolders(folder="", extensions=['tiff', 'tif']):
 
 def read_bragg_edge_fitting_ascii_format(full_file_name):
     if not Path(full_file_name).exists():
-        raise FileNotFoundError
+        raise FileNotFoundError(str(full_file_name))
 
     metadata = {'detector_offset': '',
                 'distance_detector_sample': '',

--- a/notebooks/__code/nexus_handler.py
+++ b/notebooks/__code/nexus_handler.py
@@ -16,7 +16,7 @@ def get_list_entries(nexus_file_name=None, starting_entries=None):
 		raise ValueError("Please provide a full path to a nexus file name!")
 
 	if not Path(nexus_file_name).exists():
-		raise ValueError("File do not exist!")
+		raise ValueError('File "{}" does not exist!'.format(nexus_file_name))
 
 	dict_daslogs_keys = OrderedDict()
 	with h5py.File(nexus_file_name, 'r') as nxs:
@@ -48,7 +48,7 @@ def get_entry_value(nexus_file_name=None, entry_path=None):
 		raise ValueError("Please provide a full path to a nexus file name!")
 
 	if not Path(nexus_file_name).exists():
-		raise ValueError("File do not exist!")
+		raise ValueError('File "{}" does not exist!'.format(nexus_file_name))
 
 	with h5py.File(nexus_file_name, 'r') as nxs:
 


### PR DESCRIPTION
Since travis-ci is now charging, move the code to github actions. This works with "latest" mac, ubuntu, and windows for python 3.7 and 3.8.

There are 15 failing tests (files missing from the repository) and there is something wacky with the path/modules. The tests are currently run via
```sh
cd notebooks
PYTHONPATH=. pytest
```
which should be addressed later.