### PR TITLE
switch pyoncat src to conda

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -6,14 +6,14 @@ jobs:
     run-unit-tests:
       runs-on: ubuntu-22.04
       timeout-minutes: 60
-      name: ubuntu-22.04  python 3.8
+      name: ubuntu-22.04  python 3.9
       steps:
         - uses: actions/checkout@v2
         # - uses: jurplel/install-qt-action@v2
         - uses: conda-incubator/setup-miniconda@v2
           with:
             auto-update-conda: true
-            python-version: 3.8
+            python-version: 3.9
             channels: conda-forge
             auto-activate-base: true
         - name: Map the Branch Name to a Conda Environment

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -9,14 +9,6 @@ jobs:
       name: ubuntu-22.04  python 3.9
       steps:
         - uses: actions/checkout@v2
-        # - uses: jurplel/install-qt-action@v2
-        # - name: update base os package
-        #   id: os_update
-        #   timeout-minutes: 60
-        #   shell: bash -l {0}
-        #   run: |
-        #     sudo apt-get update
-        #     sudo apt-get upgrade -y
         - uses: conda-incubator/setup-miniconda@v2
           with:
             auto-update-conda: true
@@ -34,6 +26,9 @@ jobs:
           shell: bash -l {0}
           run: |
             python -m pip install --upgrade pip
+            # NOTE: the selected action is using packages from main, which is
+            #       in compatible with those from conda-forge, a force update here
+            #       help to bypass this issue.
             conda update -n base --all -y
             conda env update -n base --file=conda/${{ steps.envname.outputs.name }}.yml
             conda install --yes --name base pytest

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -10,6 +10,13 @@ jobs:
       steps:
         - uses: actions/checkout@v2
         # - uses: jurplel/install-qt-action@v2
+        - name: update base os package
+          id: os_update
+          timeout-minutes: 60
+          shell: bash -l {0}
+          run: |
+            sudo apt-get update
+            sudo apt-get upgrade -y
         - uses: conda-incubator/setup-miniconda@v2
           with:
             auto-update-conda: true
@@ -23,7 +30,7 @@ jobs:
             prefix: "neutron-imaging"
             suffix-default: "-dev"
         - name: Install dependencies
-          timeout-minutes: 40
+          timeout-minutes: 60
           shell: bash -l {0}
           run: |
             python -m pip install --upgrade pip

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -10,13 +10,13 @@ jobs:
       steps:
         - uses: actions/checkout@v2
         # - uses: jurplel/install-qt-action@v2
-        - name: update base os package
-          id: os_update
-          timeout-minutes: 60
-          shell: bash -l {0}
-          run: |
-            sudo apt-get update
-            sudo apt-get upgrade -y
+        # - name: update base os package
+        #   id: os_update
+        #   timeout-minutes: 60
+        #   shell: bash -l {0}
+        #   run: |
+        #     sudo apt-get update
+        #     sudo apt-get upgrade -y
         - uses: conda-incubator/setup-miniconda@v2
           with:
             auto-update-conda: true
@@ -34,6 +34,7 @@ jobs:
           shell: bash -l {0}
           run: |
             python -m pip install --upgrade pip
+            conda update -n base --all -y
             conda env update -n base --file=conda/${{ steps.envname.outputs.name }}.yml
             conda install --yes --name base pytest
         - name: Run tests

--- a/conda/neutron-imaging-dev.yml
+++ b/conda/neutron-imaging-dev.yml
@@ -1,6 +1,7 @@
 name: neutron-imaging-dev
 channels:
   - conda-forge
+  - oncat
 dependencies:
   # Base
   - python
@@ -34,6 +35,8 @@ dependencies:
   - qtpy>=1.9.0
   - pyqt>=5.15,<6
   - pyqtgraph
+  # ORNL
+  - pyoncat
   # neutronimaging + pip_only_deps
   - pip
   - pip:
@@ -43,4 +46,3 @@ dependencies:
     - NeuNorm==1.5.3
     - sectorizedradialprofile
     - ImagingReso==1.7.5
-    - https://oncat.ornl.gov/packages/pyoncat-1.4.1-py3-none-any.whl

--- a/conda/neutron-imaging.yml
+++ b/conda/neutron-imaging.yml
@@ -1,6 +1,7 @@
 name: neutron-imaging
 channels:
   - conda-forge
+  - oncat
 dependencies:
   # Base
   - python
@@ -34,6 +35,8 @@ dependencies:
   - qtpy>=1.9.0
   - pyqt>=5.15,<6
   - pyqtgraph
+  # ORNL
+  - pyoncat
   # neutronimaging + pip_only_deps
   - pip
   - pip:
@@ -43,4 +46,3 @@ dependencies:
     - NeuNorm==1.5.3
     - sectorizedradialprofile
     - ImagingReso==1.7.5
-    - https://oncat.ornl.gov/packages/pyoncat-1.4.1-py3-none-any.whl

--- a/config_conda_env.sh
+++ b/config_conda_env.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# This is a special package for ORNL
-PYONCAT_LOCATION="https://oncat.ornl.gov/packages/pyoncat-1.4.1-py3-none-any.whl"
-
 # update base conda
 conda update -y -n base -c defaults conda
 
@@ -32,6 +29,8 @@ conda install -y -c conda-forge \
 
 conda install -c conda-forge nbstripout
 
+conda install -c oncat pyoncat
+
 # install additional from pip
 pip install \
     chardet \
@@ -44,7 +43,6 @@ pip install \
     ipywidgets \
     changepy \
     tqdm \
-    $PYONCAT_LOCATION
     werkzeug=2.0.1
 
 


### PR DESCRIPTION
This PR introduce the following changes:

- the source of `pyoncat` is switched from `pypi` to `conda`

> EWM item: [task3363](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=3363)